### PR TITLE
removed virgil plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [clojure-csv/clojure-csv "2.0.1"]]
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
-  :plugins [[lein-virgil "0.1.8"]])
-  
-                 
+  :plugins [])
+
+
 


### PR DESCRIPTION
Using Leiningen 2.8.1
nREPL server started on port 64350 on host 127.0.0.1 - nrepl://127.0.0.1:64350
REPL-y 0.3.7, nREPL 0.2.12
Clojure 1.9.0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_121-b13
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
    Exit: Control+D or (exit) or (quit)
 Results: Stored in vars *1, *2, *3, an exception in *e

user=> (require '[mister-rogers.wrappers :as w])
nil
user=> (w/get-test w/p)
1
user=>